### PR TITLE
Do not install MIT HRTF headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,19 +27,13 @@ list(APPEND headers
     include/AmbisonicEncoder.h
     include/Ambisonics.h
     include/AmbisonicZoomer.h
-    include/mit_hrtf_filter.h
     include/AmbisonicDecoder.h
     include/AmbisonicMicrophone.h
     include/AmbisonicSource.h
     include/BFormat.h
-    include/mit_hrtf_lib.h
     include/hrtf/hrtf.h
     include/hrtf/mit_hrtf.h
     include/hrtf/sofa_hrtf.h
-    include/normal/mit_hrtf_normal_44100.h
-    include/normal/mit_hrtf_normal_48000.h
-    include/normal/mit_hrtf_normal_88200.h
-    include/normal/mit_hrtf_normal_96000.h
     source/kiss_fft/kiss_fftr.h
     source/kiss_fft/kiss_fft.h
 )


### PR DESCRIPTION
It looks like the canonical interface for accessing the MIT HRTF data is via `include/hrtf/mit_hrtf.h`. So I don't think installing those headers is necessary. Especially when `HAVE_MIT_HRTF` is set to `OFF`, they shouldn't be installed.