### PR TITLE
Replace variable length array with vector to fix MSVC build

### DIFF
--- a/source/hrtf/mit_hrtf.cpp
+++ b/source/hrtf/mit_hrtf.cpp
@@ -7,6 +7,7 @@
 #include <mit_hrtf.h>
 #include <mit_hrtf_lib.h>
 
+#include <vector>
 
 MIT_HRTF::MIT_HRTF(unsigned i_sampleRate)
     : HRTF(i_sampleRate)
@@ -22,8 +23,8 @@ bool MIT_HRTF::get(float f_azimuth, float f_elevation, float** pfHRTF)
         nAzimuth -= 360;
     int nElevation = (int)RadiansToDegrees(f_elevation);
     //Get HRTFs for given position
-    short psHRTF[2][i_len];
-    unsigned ret = mit_hrtf_get(&nAzimuth, &nElevation, i_sampleRate, psHRTF[0], psHRTF[1]);
+    std::vector<short> psHRTF[2] = {std::vector<short>(i_len), std::vector<short>(i_len)};
+    unsigned ret = mit_hrtf_get(&nAzimuth, &nElevation, i_sampleRate, psHRTF[0].data(), psHRTF[1].data());
     if (ret == 0)
         return false;
 


### PR DESCRIPTION
When building `libspatialaudio` with `MIT_HRTF` using MSVC (Visual Studio 15 2017 Win64), I get the following error, because of the variable length array in `mit_hrtf.cpp`:
```
libspatialaudio\source\hrtf\mit_hrtf.cpp(25): error C2131: expression did not evaluate to a constant
```
Replacing the C-style array with a `std::vector` fixes the problem. The function `MIT_HRTF::get` is only ever called in the `Configure` step of the the binauralizer classes, so it's not real-time critical and vector allocations are not a problem.