### PR TITLE
Cmake: Fix mysofa finding and variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,24 +72,24 @@ set(HAVE_MYSOFA ${MYSOFA_FOUND})
 
 include_directories(include include/hrtf source source/kiss_fft ${PROJECT_BINARY_DIR})
 
-if(${MYSOFA_FOUND})
+if(MYSOFA_FOUND)
     include_directories(${MYSOFA_INCLUDE_DIRS})
-endif(${MYSOFA_FOUND})
+endif(MYSOFA_FOUND)
 
 if(BUILD_STATIC_LIBS)
     add_library(spatialaudio-static STATIC ${sources})
-    if(${MYSOFA_FOUND})
+    if(MYSOFA_FOUND)
         target_link_libraries(spatialaudio-static ${MYSOFA_LIBRARIES})
-    endif(${MYSOFA_FOUND})
+    endif(MYSOFA_FOUND)
     SET_TARGET_PROPERTIES(spatialaudio-static PROPERTIES OUTPUT_NAME spatialaudio CLEAN_DIRECT_OUTPUT 1 POSITION_INDEPENDENT_CODE ON)
     install(TARGETS spatialaudio-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(BUILD_STATIC_LIBS)
 
 if(BUILD_SHARED_LIBS)
     add_library(spatialaudio-shared SHARED ${sources})
-    if(${MYSOFA_FOUND})
+    if(MYSOFA_FOUND)
         target_link_libraries(spatialaudio-shared ${MYSOFA_LIBRARIES})
-    endif(${MYSOFA_FOUND})
+    endif(MYSOFA_FOUND)
     SET_TARGET_PROPERTIES(spatialaudio-shared PROPERTIES OUTPUT_NAME spatialaudio CLEAN_DIRECT_OUTPUT 1)
     set_property(TARGET spatialaudio-shared PROPERTY VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
     set_property(TARGET spatialaudio-shared PROPERTY SOVERSION ${PACKAGE_VERSION_MAJOR} )
@@ -104,10 +104,11 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/config.h"
 )
 
-if(${HAVE_MYSOFA})
-    set(MYSOFA_LIB "-L${MYSOFA_ROOT_DIR}/${CMAKE_INSTALL_LIBDIR} -lmysofa")
-    set(MYSOFA_INCLUDE "-I${MYSOFA_ROOT_DIR}/include")
-endif(${HAVE_MYSOFA})
+if(MYSOFA_FOUND)
+    get_filename_component(MYSOFA_LIB_DIR "${MYSOFA_LIBRARIES}" DIRECTORY)
+    set(MYSOFA_LIB "-L${MYSOFA_LIB_DIR} -lmysofa")
+    set(MYSOFA_INCLUDE "-I${MYSOFA_INCLUDE_DIRS}")
+endif(MYSOFA_FOUND)
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/spatialaudio.pc.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,9 +116,9 @@ configure_file(
     @ONLY
 )
 
-install(FILES ${headers} DESTINATION include/spatialaudio)
+install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spatialaudio)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-install(FILES ${PROJECT_BINARY_DIR}/config.h DESTINATION include/spatialaudio)
+install(FILES ${PROJECT_BINARY_DIR}/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spatialaudio)
 
 #Tarballs generation
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/cmake/Modules/FindMySofa.cmake
+++ b/cmake/Modules/FindMySofa.cmake
@@ -17,19 +17,23 @@
 #  MYSOFA_LIBRARIES           The libMySofa library.
 #  MYSOFA_INCLUDE_DIRS        The location of libMySofa headers.
 
-find_path(MYSOFA_ROOT_DIR
-    NAMES include/mysofa.h
-)
+find_package(PkgConfig QUIET)
 
-find_library(MYSOFA_LIBRARIES
-    NAMES libmysofa.a mysofa
-    HINTS ${MYSOFA_ROOT_DIR}/lib
-)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(MYSOFA libmysofa)
+endif(PKG_CONFIG_FOUND)
 
-find_path(MYSOFA_INCLUDE_DIRS
-    NAMES mysofa.h
-    HINTS ${MYSOFA_ROOT_DIR}/include
-)
+if(NOT MYSOFA_LIBRARIES)
+    find_library(MYSOFA_LIBRARIES
+        NAMES mysofa
+    )
+endif(NOT MYSOFA_LIBRARIES)
+
+if(NOT MYSOFA_INCLUDE_DIRS)
+    find_path(MYSOFA_INCLUDE_DIRS
+        NAMES mysofa.h
+    )
+endif(NOT MYSOFA_INCLUDE_DIRS)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MySofa DEFAULT_MSG


### PR DESCRIPTION
Currently, the resulting pkg-config files have
```bash
Libs: -L${libdir} -lspatialaudio -LMYSOFA_ROOT_DIR-NOTFOUND/lib -lmysofa -lm -lz
Cflags: -I${includedir} -IMYSOFA_ROOT_DIR-NOTFOUND/include
```
because the find_* commands are failing and are not properly checked

final result is
```bash
Libs: -L${libdir} -lspatialaudio -L/usr/lib/x86_64-linux-gnu -lmysofa -lm -lz
Cflags: -I${includedir} -I/usr/include
```