### PR TITLE
adm: fix invalid index with m_hoaEncoders when using Binaural

### DIFF
--- a/include/AdmRenderer.h
+++ b/include/AdmRenderer.h
@@ -197,10 +197,14 @@ namespace admrender {
 		void ClearHoaBuffer();
 
 		/**
-			Find the element of a vector matching the input. If the track types do not match or no matching
+			Find the element of a vector matching the input key. If the track types do not match or no matching
+			elements then returns -1
+		*/
+		int GetMatchingKey(std::vector<std::pair<unsigned int, TypeDefinition>>, unsigned int nElement, TypeDefinition trackType);
+		/**
+			Find the element of a vector matching the input index. If the track types do not match or no matching
 			elements then returns -1
 		*/
 		int GetMatchingIndex(std::vector<std::pair<unsigned int, TypeDefinition>>, unsigned int nElement, TypeDefinition trackType);
 	};
-
 }

--- a/source/AdmRenderer.cpp
+++ b/source/AdmRenderer.cpp
@@ -225,7 +225,7 @@ namespace admrender {
 		toPolar(metadata);
 
 		// Map from the track index to the corresponding panner index
-		int nObjectInd = GetMatchingIndex(m_pannerTrackInd, metadata.trackInd, TypeDefinition::Objects);
+		int nObjectInd = GetMatchingKey(m_pannerTrackInd, metadata.trackInd, TypeDefinition::Objects);
 
 		if (nObjectInd == -1) // this track was not declared at construction. Stopping here.
 		{
@@ -437,9 +437,9 @@ namespace admrender {
 			std::fill(m_speakerOutDiffuse[iCh].begin(), m_speakerOutDiffuse[iCh].end(), 0.f);
 	}
 
-	int CAdmRenderer::GetMatchingIndex(std::vector<std::pair<unsigned int, TypeDefinition>> vector, unsigned int nElement, TypeDefinition trackType)
+	int CAdmRenderer::GetMatchingKey(std::vector<std::pair<unsigned int, TypeDefinition>> vector, unsigned int nElement, TypeDefinition trackType)
 	{
-		// Map from the track index to the corresponding panner index
+		// Map from the track index to the corresponding panner key
 		int nInd = 0;
 		for (unsigned int i = 0; i < vector.size(); i++)
 			if (vector[i].first == nElement && vector[i].second == trackType) {
@@ -447,6 +447,22 @@ namespace admrender {
 				return nInd;
 			}
 
+		return -1;
+	}
+
+	int CAdmRenderer::GetMatchingIndex(std::vector<std::pair<unsigned int, TypeDefinition>> vector, unsigned int nElement, TypeDefinition trackType)
+	{
+		// Map from the track index to the corresponding panner index
+		int nInd = 0;
+		for (unsigned int i = 0; i < vector.size(); i++)
+		{
+			if (vector[i].second == trackType)
+			{
+				if (vector[i].first == nElement)
+					return nInd;
+				nInd++;
+			}
+		}
 		return -1;
 	}
 


### PR DESCRIPTION
GetMatchingIndex() was used by the binaural renderer to get the
m_hoaEncoders vector index, and by the renderer to get the object map key.

This led to invalid index or segfault when using the binaural renderer.
when Objects were inserted before DirectSpeakers in StreamInformation.