### PR TITLE
Fix MySofa library directory detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,7 @@ configure_file(
 )
 
 if(MYSOFA_FOUND)
-    get_filename_component(MYSOFA_LIB_DIR "${MYSOFA_LIBRARIES}" DIRECTORY)
-    set(MYSOFA_LIB "-L${MYSOFA_LIB_DIR} -lmysofa")
+    set(MYSOFA_LIB "-L${MYSOFA_LIBRARY_DIRS} -lmysofa")
     set(MYSOFA_INCLUDE "-I${MYSOFA_INCLUDE_DIRS}")
 endif(MYSOFA_FOUND)
 

--- a/cmake/Modules/FindMySofa.cmake
+++ b/cmake/Modules/FindMySofa.cmake
@@ -23,11 +23,22 @@ if(PKG_CONFIG_FOUND)
     pkg_check_modules(MYSOFA libmysofa)
 endif(PKG_CONFIG_FOUND)
 
+if(MYSOFA)
+    set(MYSOFA_INCLUDE_DIRS ${MYSOFA_PKG_CONFIG_INCLUDE_DIRS})
+    set(MYSOFA_LIBRARY_DIRS ${MYSOFA_PKG_CONFIG_LIBRARY_DIRS})
+endif()
+
 if(NOT MYSOFA_LIBRARIES)
     find_library(MYSOFA_LIBRARIES
         NAMES mysofa
     )
 endif(NOT MYSOFA_LIBRARIES)
+
+if(NOT MYSOFA_LIBRARY_DIRS)
+    find_path(MYSOFA_LIBRARY_DIRS
+        NAMES libmysofa.so
+    )
+endif(NOT MYSOFA_LIBRARY_DIRS)
 
 if(NOT MYSOFA_INCLUDE_DIRS)
     find_path(MYSOFA_INCLUDE_DIRS


### PR DESCRIPTION
Current code was causing issues because:

get_filename_component(MYSOFA_LIB_DIR "${MYSOFA_LIBRARIES}" DIRECTORY)

was nil.

Thus we had:

Libs: -L${libdir} -lspatialaudio -L -lmysofa -lm -lz

in spatialaudio.pc

And thus, while building vlc, libtool was unhappy:

libtool:   error: require no space between '-L' and '-lmysofa'

Here we use proper pkg-config feature PKG_CONFIG_LIBRARY_DIRS to get the directory set in libmysofa.pc, with a find_path fallback.