### PR TITLE
fix configuring with cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(PACKAGE_VERSION_MAJOR "0")
 set(PACKAGE_VERSION_MINOR "3")


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.