### PR TITLE
CI: Lower meson in CI to 1.1.1

### DIFF
--- a/.github/workflows/meson-multi-platform.yml
+++ b/.github/workflows/meson-multi-platform.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         build_type: [Release]
         cpp_compiler: [g++, clang++, cl]
-        meson_version: ["1.2.0"]
+        meson_version: ["1.1.1"]
         include:
           - os: windows-latest
             c_compiler: cl


### PR DESCRIPTION
This is the latest patch version of the 1.1.x minor release (which is the minimum we require in the meson build).