### PR TITLE
CMake: Remove leftover debug message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,6 @@ if(NOT BUILD_SHARED_LIBS)
     set(SPATIALAUDIO_STATIC YES)
 endif()
 
-message("Type: $<TARGET_PROPERTY:spatialaudio,TYPE>")
-
 configure_file(
     "include/SpatialaudioConfig.h.in"
     "include/SpatialaudioConfig.h"


### PR DESCRIPTION
This was forgotten in 0c9fc9a