### PR TITLE
CI: switch macos-13 to macos-15

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -17,7 +17,7 @@ jobs:
 
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
         build_type: [Release]
         cpp_compiler: [g++, clang++, cl]
         include:
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-13
+          - os: macos-15-intel
             c_compiler: clang
             cpp_compiler: clang++
           - os: macos-latest
@@ -43,9 +43,9 @@ jobs:
             cpp_compiler: clang++
           - os: ubuntu-latest
             cpp_compiler: cl
-          - os: macos-13
+          - os: macos-15-intel
             cpp_compiler: cl
-          - os: macos-13
+          - os: macos-15-intel
             cpp_compiler: g++
           - os: macos-latest
             cpp_compiler: cl

--- a/.github/workflows/meson-multi-platform.yml
+++ b/.github/workflows/meson-multi-platform.yml
@@ -17,7 +17,7 @@ jobs:
 
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
         build_type: [Release]
         cpp_compiler: [g++, clang++, cl]
         meson_version: ["1.2.0"]
@@ -31,7 +31,7 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-13
+          - os: macos-15-intel
             c_compiler: clang
             cpp_compiler: clang++
           - os: macos-latest
@@ -44,9 +44,9 @@ jobs:
             cpp_compiler: clang++
           - os: ubuntu-latest
             cpp_compiler: cl
-          - os: macos-13
+          - os: macos-15-intel
             cpp_compiler: cl
-          - os: macos-13
+          - os: macos-15-intel
             cpp_compiler: g++
           - os: macos-latest
             cpp_compiler: cl


### PR DESCRIPTION
macos-13 is not available anymore. It was an Intel image [^1].
macos-13-xlarge being the arm64 one.

The oldest Intel image currently available is macos-14-large.
However the "-large" images seem to not be available unlimited for free.
We need to use macos-15-intel to free image targeting macOS Intel [^2].

Any macOS runner should be able to compile the code for both and probably run
tests for both architectures as well.

[^1]: https://github.com/actions/runner-images/commit/e664a5c3f32e9212d37658d11e258b1f63e99d45
[^2]: https://github.com/actions/runner-images/blob/c218bde724e0ae9730d9ce101bca654a4c2e521d/README.md
