### PR TITLE
Always define _USE_MATH_DEFINES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ target_include_directories(spatialaudio
 target_compile_definitions(spatialaudio
     PRIVATE
         SPATIALAUDIO_COMPILATION
+    PUBLIC
+        _USE_MATH_DEFINES
 )
 
 if(MYSOFA_FOUND)

--- a/cmake/spatialaudio.pc.cmake
+++ b/cmake/spatialaudio.pc.cmake
@@ -6,4 +6,4 @@ Name: spatialaudio
 Description: Spatial audio rendering library
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lspatialaudio @MYSOFA_LIB@ -lm -lz
-Cflags: -I${includedir} @MYSOFA_INCLUDE@
+Cflags: -I${includedir} @MYSOFA_INCLUDE@ -D_USE_MATH_DEFINES

--- a/include/AmbisonicCommons.h
+++ b/include/AmbisonicCommons.h
@@ -16,7 +16,9 @@
 #ifndef SPATIALAUDIO_AMBISONIC_COMMONS_H
 #define SPATIALAUDIO_AMBISONIC_COMMONS_H
 
-#define _USE_MATH_DEFINES
+#ifndef _USE_MATH_DEFINES
+# define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <cmath>
 #include <memory.h>

--- a/include/AmbisonicCommons.h
+++ b/include/AmbisonicCommons.h
@@ -19,7 +19,6 @@
 #ifndef _USE_MATH_DEFINES
 # define _USE_MATH_DEFINES
 #endif
-#include <math.h>
 #include <cmath>
 #include <memory.h>
 

--- a/include/Tools.h
+++ b/include/Tools.h
@@ -18,7 +18,6 @@
 #ifndef _USE_MATH_DEFINES
 # define _USE_MATH_DEFINES
 #endif
-#include<math.h>
 #include<cmath>
 #include<numeric>
 #include<algorithm>

--- a/include/Tools.h
+++ b/include/Tools.h
@@ -15,7 +15,9 @@
 #ifndef SPATIALAUDIO_TOOLS_H
 #define SPATIALAUDIO_TOOLS_H
 
-#define _USE_MATH_DEFINES
+#ifndef _USE_MATH_DEFINES
+# define _USE_MATH_DEFINES
+#endif
 #include<math.h>
 #include<cmath>
 #include<numeric>

--- a/include/Tools.h
+++ b/include/Tools.h
@@ -18,9 +18,9 @@
 #ifndef _USE_MATH_DEFINES
 # define _USE_MATH_DEFINES
 #endif
-#include<cmath>
-#include<numeric>
-#include<algorithm>
+#include <cmath>
+#include <numeric>
+#include <algorithm>
 #include <iostream>
 #include <vector>
 #include "assert.h"

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ libspatialaudio_dep = declare_dependency(
     include_directories : spatialaudio_incdirs,
     dependencies : dependencies,
     link_with : spatialaudio_lib,
+    compile_args : ['-D_USE_MATH_DEFINES'],
 )
 meson.override_dependency('libspatialaudio', libspatialaudio_dep)
 

--- a/source/Decorrelator.cpp
+++ b/source/Decorrelator.cpp
@@ -12,7 +12,7 @@
 
 #include "Decorrelator.h"
 
-#include<random>
+#include <random>
 
 namespace spaudio {
 

--- a/source/PointSourcePannerGainCalc.cpp
+++ b/source/PointSourcePannerGainCalc.cpp
@@ -364,7 +364,7 @@ namespace spaudio {
             {
                 upperLayerSet.push_back(iSpk);
                 // TODO: consider remapping azimuth to range -180 to 180
-                maxUpperAz = std::max(maxUpperAz, abs(layout.getChannel(iSpk).getPolarPositionNominal().azimuth));
+                maxUpperAz = std::max(maxUpperAz, std::abs(layout.getChannel(iSpk).getPolarPositionNominal().azimuth));
                 meanUpperEl += layout.getChannel(iSpk).getPolarPosition().elevation;
             }
             else if (el >= -10 && el <= 10)
@@ -376,7 +376,7 @@ namespace spaudio {
             {
                 lowerLayerSet.push_back(iSpk);
                 // TODO: consider remapping azimuth to range -180 to 180
-                maxLowerAz = std::max(maxLowerAz, abs(layout.getChannel(iSpk).getPolarPositionNominal().azimuth));
+                maxLowerAz = std::max(maxLowerAz, std::abs(layout.getChannel(iSpk).getPolarPositionNominal().azimuth));
                 meanLowerEl += layout.getChannel(iSpk).getPolarPosition().elevation;
             }
         }
@@ -390,7 +390,7 @@ namespace spaudio {
             auto name = layout.getChannel(midLayerSet[iMid]).getChannelName();
             double azimuth = layout.getChannel(midLayerSet[iMid]).getPolarPosition().azimuth;
             // Lower layer
-            if ((lowerLayerSet.size() > 0 && abs(azimuth) > maxLowerAz + 40.) || lowerLayerSet.size() == 0)
+            if ((lowerLayerSet.size() > 0 && std::abs(azimuth) > maxLowerAz + 40.) || lowerLayerSet.size() == 0)
             {
                 m_downmixMapping.push_back(iMid);
                 name.at(0) = 'B';
@@ -406,7 +406,7 @@ namespace spaudio {
             auto name = layout.getChannel(midLayerSet[iMid]).getChannelName();
             double azimuth = layout.getChannel(midLayerSet[iMid]).getPolarPosition().azimuth;
             // Upper layer
-            if ((upperLayerSet.size() > 0 && abs(azimuth) > maxUpperAz + 40.) || upperLayerSet.size() == 0)
+            if ((upperLayerSet.size() > 0 && std::abs(azimuth) > maxUpperAz + 40.) || upperLayerSet.size() == 0)
             {
                 m_downmixMapping.push_back(iMid);
                 name.at(0) = 'U';

--- a/source/PointSourcePannerGainCalc.cpp
+++ b/source/PointSourcePannerGainCalc.cpp
@@ -16,8 +16,8 @@
 
 #include "LoudspeakerLayoutHulls.h"
 
-#include<cmath>
-#include<string>
+#include <cmath>
+#include <string>
 #include <map>
 
 namespace spaudio {

--- a/source/RegionHandlers.cpp
+++ b/source/RegionHandlers.cpp
@@ -12,7 +12,7 @@
 /*############################################################################*/
 
 #include "RegionHandlers.h"
-#include<string>
+#include <string>
 #include <map>
 
 namespace spaudio {

--- a/source/Renderer.cpp
+++ b/source/Renderer.cpp
@@ -13,8 +13,8 @@
 /*############################################################################*/
 
 #include "Renderer.h"
-#include<type_traits>
-#include<iostream>
+#include <type_traits>
+#include <iostream>
 
 namespace spaudio {
 

--- a/source/adm/DirectSpeakersGainCalc.cpp
+++ b/source/adm/DirectSpeakersGainCalc.cpp
@@ -13,7 +13,7 @@
 /*############################################################################*/
 
 #include "adm/DirectSpeakersGainCalc.h"
-#include<string>
+#include <string>
 #include <map>
 
 namespace spaudio {

--- a/source/meson.build
+++ b/source/meson.build
@@ -39,7 +39,7 @@ spatialaudio_sources = files(
     'ObjectPanner.cpp',
 )
 
-spatialaudio_clike_args = ['-DSPATIALAUDIO_COMPILATION']
+spatialaudio_clike_args = ['-DSPATIALAUDIO_COMPILATION', '-D_USE_MATH_DEFINES']
 
 # Extract version info from header
 spatialaudio_api_version = cpp.get_define('SPATIALAUDIO_API_VERSION_STRING',


### PR DESCRIPTION
The public headers use `M_PI` and `M_PI_2` which are defined when including `<cmath>` (or `math.h`) and `_USE_MATH_DEFINES` is defined (and some other defines are possible as well: `#if !defined(__STRICT_ANSI__) || defined(_POSIX_C_SOURCE) || defined(_POSIX_SOURCE) || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE) || defined(_USE_MATH_DEFINES)`)

In my LLVM 22 toolchain `<string>` includes `<cmath>`. And it's included before the local header in many cases (as well as most toolchain headers are included before the local headers). And even if it was not the case, an app using the public headers could be including `<cmath>` before including our headers. In that case `M_PI` and `M_PI_2` won't be defined. So we need to make sure `_USE_MATH_DEFINES` is defined before using our headers.