### PR TITLE
Throw when unable to initialize mysofa

### DIFF
--- a/source/hrtf/sofa_hrtf.cpp
+++ b/source/hrtf/sofa_hrtf.cpp
@@ -19,10 +19,7 @@ namespace spaudio {
 
         hrtf = mysofa_open(path.c_str(), i_sampleRate, &i_internalLength, &err);
         if (hrtf == nullptr)
-        {
-            std::cout << "Could not load the SOFA HRTF." << std::endl;
-            return;
-        }
+            throw std::runtime_error("Could not load the SOFA HRTF");
 
         i_filterExtraLength = i_internalLength / 2;
         i_len = i_internalLength + i_filterExtraLength;


### PR DESCRIPTION
Do not silently create a unusable SOFA_HRTF object, instead throw an exception when mysofa did not initialize properly, like when provided with no or a unusable/bogus HRTF file.

That way the caller can properly handle this error condition instead of crashing later due to the nullptr.

While this technically breaks the API contract, as this did not throw before, this is clearly a better outcome than not handling the error.

Fix #88 