### PR TITLE
Fix compilation with older GCC versions

### DIFF
--- a/include/AmbisonicProcessor.h
+++ b/include/AmbisonicProcessor.h
@@ -109,7 +109,7 @@ namespace spaudio {
      */
 
     class
-        SPAUDIO_DEPRECATED("This class is deprecated. Please use AmbisonicRotator class instead.")
+        SPAUDIO_DEPRECATED("Please use AmbisonicRotator class instead.")
         SPAUDIO_API
     AmbisonicProcessor : public AmbisonicBase
     {

--- a/include/AmbisonicProcessor.h
+++ b/include/AmbisonicProcessor.h
@@ -108,8 +108,9 @@ namespace spaudio {
      *  Please use AmbisonicRotator instead.
      */
 
-    class SPAUDIO_API
-        [[deprecated("This class is deprecated. Please use AmbisonicRotator class instead.")]]
+    class
+        SPAUDIO_DEPRECATED("This class is deprecated. Please use AmbisonicRotator class instead.")
+        SPAUDIO_API
     AmbisonicProcessor : public AmbisonicBase
     {
     public:

--- a/include/AmbisonicShelfFilters.h
+++ b/include/AmbisonicShelfFilters.h
@@ -26,8 +26,9 @@ namespace spaudio {
     /** This class applies frequency dependent basic & max-rE optimisation to a B-format signal using linear phase FIR filters.
      *  This class is deprecated in favour of AmbisonicOptimFilters, which uses LinkwitzRiley IIR filters to apply frequency dependent gains.
      */
-    class SPAUDIO_API
-        [[deprecated("This class is deprecated. Please use AmbisonicOptimFilters class instead.")]]
+    class
+        SPAUDIO_DEPRECATED("This class is deprecated. Please use AmbisonicOptimFilters class instead.")
+        SPAUDIO_API
     AmbisonicShelfFilters : public AmbisonicBase
     {
     public:

--- a/include/AmbisonicShelfFilters.h
+++ b/include/AmbisonicShelfFilters.h
@@ -27,7 +27,7 @@ namespace spaudio {
      *  This class is deprecated in favour of AmbisonicOptimFilters, which uses LinkwitzRiley IIR filters to apply frequency dependent gains.
      */
     class
-        SPAUDIO_DEPRECATED("This class is deprecated. Please use AmbisonicOptimFilters class instead.")
+        SPAUDIO_DEPRECATED("Please use AmbisonicOptimFilters class instead.")
         SPAUDIO_API
     AmbisonicShelfFilters : public AmbisonicBase
     {

--- a/include/SpatialaudioAPI.h
+++ b/include/SpatialaudioAPI.h
@@ -35,4 +35,14 @@
 # define SPAUDIO_API SPATIALAUDIO_IMPORT
 #endif
 
+// Deprecation annotation
+// For GCC 12 and older we must not mix the attribute syntax
+// styles, so in that case, we use __attribute__(()) here, else
+// we just use the normal C++ attribute syntax
+#if defined(__GNUC__) && (__GNUC__ < 13)
+# define SPAUDIO_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+# define SPAUDIO_DEPRECATED(msg) [[deprecated(msg)]]
+#endif
+
 #endif /* SPATIALAUDIO_API_H */


### PR DESCRIPTION
GCC versions 12 and older choke when mixing the C++ attribute syntax `[[]]` with the GCC/Clang style `__attribute__(())` one, to work around this, this PR adds a new `SPAUDIO_DEPRECATED` macro that is defined accordingly to avoid such mixing on affected versions.

Fixes the build failure observed for https://code.videolan.org/videolan/vlc/-/merge_requests/8700