### PR TITLE
meson: Do not build test executables by default

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,13 +1,21 @@
 # Tests
 
-e = executable('TestInsideAngleRange', 'TestInsideAngleRange.cpp', dependencies: [libspatialaudio_dep])
+e = executable('TestInsideAngleRange', 'TestInsideAngleRange.cpp',
+               dependencies: [libspatialaudio_dep],
+               build_by_default: false)
 test('TestInsideAngleRange', e)
 
-e = executable('TestAmbisonicShelfFilters', 'TestAmbisonicShelfFilters.cpp', dependencies: [libspatialaudio_dep])
+e = executable('TestAmbisonicShelfFilters', 'TestAmbisonicShelfFilters.cpp',
+               dependencies: [libspatialaudio_dep],
+               build_by_default: false)
 test('TestAmbisonicShelfFilters', e)
 
-e = executable('TestAmbisonicDecoderPresets', 'TestAmbisonicDecoderPresets.cpp', dependencies: [libspatialaudio_dep])
+e = executable('TestAmbisonicDecoderPresets', 'TestAmbisonicDecoderPresets.cpp',
+               dependencies: [libspatialaudio_dep],
+               build_by_default: false)
 test('TestAmbisonicDecoderPresets', e)
 
-e = executable('TestRenderer', 'TestRenderer.cpp', dependencies: [libspatialaudio_dep])
+e = executable('TestRenderer', 'TestRenderer.cpp',
+               dependencies: [libspatialaudio_dep],
+               build_by_default: false)
 test('TestRenderer', e)


### PR DESCRIPTION
Now they will only be built when actually needed, similar to how autotools handles this.

Fix #83